### PR TITLE
Compile with VS2010+

### DIFF
--- a/mmh3module.cpp
+++ b/mmh3module.cpp
@@ -3,7 +3,7 @@
 #include <Python.h>
 #include "murmur_hash_3.hpp"
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && _MSC_VER < 1600
 // Visual C++
 typedef signed char int8_t;
 typedef signed long int32_t;

--- a/murmur_hash_3.hpp
+++ b/murmur_hash_3.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && _MSC_VER < 1600
 typedef unsigned char uint8_t;
 typedef unsigned long uint32_t;
 typedef unsigned __int64 uint64_t;


### PR DESCRIPTION
Visual Studio 2010 and later come with stdint.h but also define uint32_t
and others elsewhere which cause compilation failures