### PR TITLE
Fix deprecate warning

### DIFF
--- a/mmh3module.cpp
+++ b/mmh3module.cpp
@@ -1,3 +1,4 @@
+#define PY_SSIZE_T_CLEAN
 #include <stdio.h>
 #include <string.h>
 #include <Python.h>


### PR DESCRIPTION
It complains with the following warning when running under Python 3.8+
```Python
Python 3.8.6 (v3.8.6:db455296be, Sep 23 2020, 13:31:39)
[Clang 6.0 (clang-600.0.57)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import mmh3
>>> mmh3.hash("hello")
<stdin>:1: DeprecationWarning: PY_SSIZE_T_CLEAN will be required for '#' formats
613153351
```
which was added in [Python 3.8 source code](https://github.com/python/cpython/commit/0895793194cd5f1153d2a286ed3a4fc876149b16).